### PR TITLE
Fix visual bugs in progress bars

### DIFF
--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -94,20 +94,26 @@ hr {
 }
 
 .meter {
+  position: relative;
   background-color: $color-light;
   border-radius: 0.5em;
+  overflow: hidden;
   height: 80%;
+  display: flex;
+  align-items: center;
   -webkit-box-shadow: inset 0px 0px 3px 0px rgba(0, 0, 0, 0.5);
   -moz-box-shadow: inset 0px 0px 3px 0px rgba(0, 0, 0, 0.5);
   box-shadow: inset 0px 0px 3px 0px rgba(0, 0, 0, 0.5);
 
   & .progress {
-    display: flex;
+    position: relative;
     height: 100%;
     background-color: $color-green;
-    border-radius: 0.5em 0 0 0.5em;
-    align-items: center;
-    padding-left: 1em;
+  }
+
+  & .label {
+    position: absolute;
+    text-indent: 1em;
     font-family: sans-serif;
     font-weight: 700;
   }

--- a/components/Ally.js
+++ b/components/Ally.js
@@ -9,7 +9,7 @@ export default class Ally extends Component {
   render() {
     const styles = {
       prog: {
-        width: `${Math.floor(
+        flexBasis: `${Math.floor(
           (this.props.table.current.sumTotal /
             this.props.table.total.sumTotal) *
             100

--- a/components/Item.js
+++ b/components/Item.js
@@ -14,7 +14,7 @@ export default class Item extends Component {
   render() {
     const styles = {
       prog: {
-        width: `${Math.floor((this.props.current / this.props.total) * 100)}%`,
+        flexBasis: `${Math.floor((this.props.current / this.props.total) * 100)}%`,
       },
     };
     return (
@@ -33,6 +33,8 @@ export default class Item extends Component {
           </span>
           <div className='meter'>
             <span className='progress' style={styles.prog}>
+            </span>
+            <span className='label'>
               {this.formatNumber(this.props.current)} /{' '}
               {this.formatNumber(this.props.total)}
             </span>


### PR DESCRIPTION
This PR addresses a small visual issue regarding the progress bar. Prior to this fix, the progress bar would spill out the end on progress values >99%. This also addresses the progress label being wrapped inside the progress bar at smaller widths.